### PR TITLE
Added support for headers in the settings.

### DIFF
--- a/src/Cake.Curl.Tests/CurlDownloadFileTests.cs
+++ b/src/Cake.Curl.Tests/CurlDownloadFileTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Curl.Tests.Fixtures;
@@ -213,6 +214,44 @@ namespace Cake.Curl.Tests
 
                 // Then
                 Assert.Contains("--progress-bar", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_Headers_In_Quotes_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { Headers = new Dictionary<string, string> {
+                        { "name", "value" }
+                    } }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--header \"name:value\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Multiple_Headers_In_Quotes_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { Headers = new Dictionary<string, string> {
+                        { "name1", "value1" },
+                        { "name2", "value2" },
+                        { "name3", "value3" }
+                    } }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--header \"name1:value1\" --header \"name2:value2\" --header \"name3:value3\"", result.Args);
             }
         }
     }

--- a/src/Cake.Curl.Tests/CurlDownloadMultipleFilesTests.cs
+++ b/src/Cake.Curl.Tests/CurlDownloadMultipleFilesTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Curl.Tests.Fixtures;
@@ -245,6 +246,44 @@ namespace Cake.Curl.Tests
 
                 // Then
                 Assert.Contains("--progress-bar", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_Headers_In_Quotes_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { Headers = new Dictionary<string, string> {
+                        { "name", "value" }
+                    } }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--header \"name:value\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_Multiple_Headers_In_Quotes_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { Headers = new Dictionary<string, string> {
+                        { "name1", "value1" },
+                        { "name2", "value2" },
+                        { "name3", "value3" }
+                    } }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--header \"name1:value1\" --header \"name2:value2\" --header \"name3:value3\"", result.Args);
             }
         }
     }

--- a/src/Cake.Curl/ArgumentsExtensions.cs
+++ b/src/Cake.Curl/ArgumentsExtensions.cs
@@ -25,6 +25,16 @@ namespace Cake.Curl
                     "--user",
                     $"{settings.Username}:{settings.Password}");
             }
+
+            if (settings.Headers != null)
+            {
+                foreach (var item in settings.Headers)
+                {
+                    arguments.AppendSwitchQuoted(
+                    "--header",
+                    $"{item.Key}:{item.Value}");
+                }
+            }
         }
     }
 }

--- a/src/Cake.Curl/CurlSettings.cs
+++ b/src/Cake.Curl/CurlSettings.cs
@@ -1,4 +1,5 @@
 using Cake.Core.Tooling;
+using System.Collections.Generic;
 
 namespace Cake.Curl
 {
@@ -35,5 +36,10 @@ namespace Cake.Curl
         /// Gets or sets the password to use when authenticating to the remote host.
         /// </summary>
         public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the header to use when communicating to the remote host.
+        /// </summary>
+        public IDictionary<string, string> Headers { get; set; }
     }
 }


### PR DESCRIPTION
This pull request adds support for using custom HTTP headers with CURL. For each header, it appends an argument like `--header "name:value"` to the CURL command. Unit tests are included. Related issue https://github.com/ecampidoglio/Cake.Curl/issues/4. 

I had to upgrade the project to use the .cproj project system to be able to run unit tests. If you want I could create another pull request for that. 