### PR TITLE
Add support for retry options (#12)

### DIFF
--- a/src/Cake.Curl.Tests/CurlDownloadFileTests.cs
+++ b/src/Cake.Curl.Tests/CurlDownloadFileTests.cs
@@ -341,6 +341,134 @@ namespace Cake.Curl.Tests
                 // Then
                 Assert.DoesNotContain("--fail", result.Args);
             }
+
+            [Fact]
+            public void Should_Set_The_Retry_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { Retry = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_Retry_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { Retry = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryDelay_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { RetryDelay = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-delay 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryDelay_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { RetryDelay = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-delay", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryMaxTime_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { RetryMaxTime = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-max-time 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryMaxTme_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { RetryMaxTime = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-max-time", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryConnRefused_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { RetryConnRefused = true }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-connrefused", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryConnRefused_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadFileFixture
+                {
+                    Settings = { RetryConnRefused = false }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-connrefused", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Curl.Tests/CurlDownloadFileTests.cs
+++ b/src/Cake.Curl.Tests/CurlDownloadFileTests.cs
@@ -348,14 +348,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { Retry = 1000 }
+                    Settings = { RetryCount = 3 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry 1000", result.Args);
+                Assert.Contains("--retry 3", result.Args);
             }
 
             [Fact]
@@ -364,7 +364,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { Retry = 0 }
+                    Settings = { RetryCount = 0 }
                 };
 
                 // When
@@ -380,14 +380,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { RetryDelay = 1000 }
+                    Settings = { RetryDelaySeconds = 30 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry-delay 1000", result.Args);
+                Assert.Contains("--retry-delay 30", result.Args);
             }
 
             [Fact]
@@ -396,7 +396,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { RetryDelay = 0 }
+                    Settings = { RetryDelaySeconds = 0 }
                 };
 
                 // When
@@ -412,14 +412,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { RetryMaxTime = 1000 }
+                    Settings = { RetryMaxTimeSeconds = 300 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry-max-time 1000", result.Args);
+                Assert.Contains("--retry-max-time 300", result.Args);
             }
 
             [Fact]
@@ -428,7 +428,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { RetryMaxTime = 0 }
+                    Settings = { RetryMaxTimeSeconds = 0 }
                 };
 
                 // When
@@ -444,7 +444,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { RetryConnRefused = true }
+                    Settings = { RetryOnConnectionRefused = true }
                 };
 
                 // When
@@ -460,7 +460,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadFileFixture
                 {
-                    Settings = { RetryConnRefused = false }
+                    Settings = { RetryOnConnectionRefused = false }
                 };
 
                 // When

--- a/src/Cake.Curl.Tests/CurlDownloadMultipleFilesTests.cs
+++ b/src/Cake.Curl.Tests/CurlDownloadMultipleFilesTests.cs
@@ -373,6 +373,134 @@ namespace Cake.Curl.Tests
                 // Then
                 Assert.DoesNotContain("--fail", result.Args);
             }
+
+            [Fact]
+            public void Should_Set_The_Retry_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { Retry = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_Retry_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { Retry = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryDelay_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { RetryDelay = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-delay 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryDelay_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { RetryDelay = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-delay", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryMaxTime_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { RetryMaxTime = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-max-time 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryMaxTme_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { RetryMaxTime = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-max-time", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryConnRefused_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { RetryConnRefused = true }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-connrefused", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryConnRefused_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlDownloadMultipleFilesFixture
+                {
+                    Settings = { RetryConnRefused = false }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-connrefused", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Curl.Tests/CurlDownloadMultipleFilesTests.cs
+++ b/src/Cake.Curl.Tests/CurlDownloadMultipleFilesTests.cs
@@ -380,14 +380,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { Retry = 1000 }
+                    Settings = { RetryCount = 3 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry 1000", result.Args);
+                Assert.Contains("--retry 3", result.Args);
             }
 
             [Fact]
@@ -396,7 +396,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { Retry = 0 }
+                    Settings = { RetryCount = 0 }
                 };
 
                 // When
@@ -412,14 +412,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { RetryDelay = 1000 }
+                    Settings = { RetryDelaySeconds = 30 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry-delay 1000", result.Args);
+                Assert.Contains("--retry-delay 30", result.Args);
             }
 
             [Fact]
@@ -428,7 +428,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { RetryDelay = 0 }
+                    Settings = { RetryDelaySeconds = 0 }
                 };
 
                 // When
@@ -444,14 +444,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { RetryMaxTime = 1000 }
+                    Settings = { RetryMaxTimeSeconds = 300 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry-max-time 1000", result.Args);
+                Assert.Contains("--retry-max-time 300", result.Args);
             }
 
             [Fact]
@@ -460,7 +460,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { RetryMaxTime = 0 }
+                    Settings = { RetryMaxTimeSeconds = 0 }
                 };
 
                 // When
@@ -476,7 +476,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { RetryConnRefused = true }
+                    Settings = { RetryOnConnectionRefused = true }
                 };
 
                 // When
@@ -492,7 +492,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlDownloadMultipleFilesFixture
                 {
-                    Settings = { RetryConnRefused = false }
+                    Settings = { RetryOnConnectionRefused = false }
                 };
 
                 // When

--- a/src/Cake.Curl.Tests/CurlUploadFileTests.cs
+++ b/src/Cake.Curl.Tests/CurlUploadFileTests.cs
@@ -349,6 +349,134 @@ namespace Cake.Curl.Tests
                 // Then
                 Assert.DoesNotContain("--fail", result.Args);
             }
+
+            [Fact]
+            public void Should_Set_The_Retry_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { Retry = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_Retry_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { Retry = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryDelay_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { RetryDelay = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-delay 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryDelay_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { RetryDelay = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-delay", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryMaxTime_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { RetryMaxTime = 1000 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-max-time 1000", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryMaxTme_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { RetryMaxTime = 0 }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-max-time", result.Args);
+            }
+
+            [Fact]
+            public void Should_Set_The_RetryConnRefused_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { RetryConnRefused = true }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Contains("--retry-connrefused", result.Args);
+            }
+
+            [Fact]
+            public void Should_Not_Set_The_RetryConnRefused_Option_As_Argument()
+            {
+                // Given
+                var fixture = new CurlUploadFileFixture
+                {
+                    Settings = { RetryConnRefused = false }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.DoesNotContain("--retry-connrefused", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.Curl.Tests/CurlUploadFileTests.cs
+++ b/src/Cake.Curl.Tests/CurlUploadFileTests.cs
@@ -356,14 +356,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { Retry = 1000 }
+                    Settings = { RetryCount = 3 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry 1000", result.Args);
+                Assert.Contains("--retry 3", result.Args);
             }
 
             [Fact]
@@ -372,7 +372,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { Retry = 0 }
+                    Settings = { RetryCount = 0 }
                 };
 
                 // When
@@ -388,14 +388,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { RetryDelay = 1000 }
+                    Settings = { RetryDelaySeconds = 30 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry-delay 1000", result.Args);
+                Assert.Contains("--retry-delay 30", result.Args);
             }
 
             [Fact]
@@ -404,7 +404,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { RetryDelay = 0 }
+                    Settings = { RetryDelaySeconds = 0 }
                 };
 
                 // When
@@ -420,14 +420,14 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { RetryMaxTime = 1000 }
+                    Settings = { RetryMaxTimeSeconds = 300 }
                 };
 
                 // When
                 var result = fixture.Run();
 
                 // Then
-                Assert.Contains("--retry-max-time 1000", result.Args);
+                Assert.Contains("--retry-max-time 300", result.Args);
             }
 
             [Fact]
@@ -436,7 +436,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { RetryMaxTime = 0 }
+                    Settings = { RetryMaxTimeSeconds = 0 }
                 };
 
                 // When
@@ -452,7 +452,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { RetryConnRefused = true }
+                    Settings = { RetryOnConnectionRefused = true }
                 };
 
                 // When
@@ -468,7 +468,7 @@ namespace Cake.Curl.Tests
                 // Given
                 var fixture = new CurlUploadFileFixture
                 {
-                    Settings = { RetryConnRefused = false }
+                    Settings = { RetryOnConnectionRefused = false }
                 };
 
                 // When

--- a/src/Cake.Curl/ArgumentsExtensions.cs
+++ b/src/Cake.Curl/ArgumentsExtensions.cs
@@ -1,5 +1,6 @@
 using Cake.Core;
 using Cake.Core.IO;
+using static System.FormattableString;
 
 namespace Cake.Curl
 {
@@ -51,6 +52,26 @@ namespace Cake.Curl
             if (settings.Fail)
             {
                 arguments.Append("--fail");
+            }
+
+            if (settings.Retry > 0)
+            {
+                arguments.AppendSwitch("--retry", Invariant($"{settings.Retry}"));
+            }
+
+            if (settings.RetryDelay > 0)
+            {
+                arguments.AppendSwitch("--retry-delay", Invariant($"{settings.RetryDelay}"));
+            }
+
+            if (settings.RetryMaxTime > 0)
+            {
+                arguments.AppendSwitch("--retry-max-time", Invariant($"{settings.RetryMaxTime}"));
+            }
+
+            if (settings.RetryConnRefused)
+            {
+                arguments.Append("--retry-connrefused");
             }
         }
     }

--- a/src/Cake.Curl/ArgumentsExtensions.cs
+++ b/src/Cake.Curl/ArgumentsExtensions.cs
@@ -1,6 +1,5 @@
 using Cake.Core;
 using Cake.Core.IO;
-using static System.FormattableString;
 
 namespace Cake.Curl
 {
@@ -54,22 +53,22 @@ namespace Cake.Curl
                 arguments.Append("--fail");
             }
 
-            if (settings.Retry > 0)
+            if (settings.RetryCount > 0)
             {
-                arguments.AppendSwitch("--retry", Invariant($"{settings.Retry}"));
+                arguments.AppendSwitch("--retry", settings.RetryCount.ToString());
             }
 
-            if (settings.RetryDelay > 0)
+            if (settings.RetryDelaySeconds > 0)
             {
-                arguments.AppendSwitch("--retry-delay", Invariant($"{settings.RetryDelay}"));
+                arguments.AppendSwitch("--retry-delay", settings.RetryDelaySeconds.ToString());
             }
 
-            if (settings.RetryMaxTime > 0)
+            if (settings.RetryMaxTimeSeconds > 0)
             {
-                arguments.AppendSwitch("--retry-max-time", Invariant($"{settings.RetryMaxTime}"));
+                arguments.AppendSwitch("--retry-max-time", settings.RetryMaxTimeSeconds.ToString());
             }
 
-            if (settings.RetryConnRefused)
+            if (settings.RetryOnConnectionRefused)
             {
                 arguments.Append("--retry-connrefused");
             }

--- a/src/Cake.Curl/CurlSettings.cs
+++ b/src/Cake.Curl/CurlSettings.cs
@@ -94,5 +94,49 @@ namespace Cake.Curl
         /// and <code>407</code>) will slip through.
         /// </remarks>
         public bool Fail { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of retries if a transient error is returned when curl performs a transfer, it will retry this number of times before giving up.
+        /// </summary>
+        /// <remarks>
+        /// Setting the number to zero makes curl do no retries (which is the default).
+        /// Transient error means either: a timeout, an FTP 4xx response code or an HTTP 408 or 5xx response code.
+        /// When curl is about to retry a transfer, it will first wait one second and then for all forthcoming retries
+        /// it will double the waiting time until it reaches 10 minutes which then will be the delay between the rest of the retries.
+        /// By using <a href="https://curl.haxx.se/docs/manpage.html#--retry-delay">--retry-delay</a> you disable this exponential backoff algorithm.
+        /// See also <a href="https://curl.haxx.se/docs/manpage.html#--retry-max-time">--retry-max-time</a> to limit the total time allowed for retries.
+        /// </remarks>
+        public uint Retry { get; set; }
+
+        /// <summary>
+        /// Gets or sets the amount of time in seconds before each retry when a transfer has failed with a transient error
+        /// (it changes the default backoff time algorithm between retries).
+        /// </summary>
+        /// <remarks>
+        /// This option is only interesting if <a href="https://curl.haxx.se/docs/manpage.html#--retry">--retry</a> is also used.
+        /// Setting this delay to zero will make curl use the default backoff time.
+        /// </remarks>
+        public uint RetryDelay { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum time in seconds for retries to be done.
+        /// </summary>
+        /// <remarks>
+        /// The retry timer is reset before the first transfer attempt.
+        /// Retries will be done as usual (see <a href="https://curl.haxx.se/docs/manpage.html#--retry">--retry</a>) as long as the timer hasn't reached this given limit.
+        /// Notice that if the timer hasn't reached the limit, the request will be made and while performing, it may take longer than this given time period.
+        /// To limit a single request´s maximum time, use <a href="https://curl.haxx.se/docs/manpage.html#-m">--max-time</a>.
+        /// Set this option to zero to not timeout retries.
+        /// </remarks>
+        public uint RetryMaxTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether curl should consider <code>ECONNREFUSED</code> (in addition to the other conditions) as a transient error
+        /// for <a href="https://curl.haxx.se/docs/manpage.html#--retry">--retry</a>.
+        /// </summary>
+        /// <remarks>
+        /// This option is used together with <a href="https://curl.haxx.se/docs/manpage.html#--retry">--retry</a>.
+        /// </remarks>
+        public bool RetryConnRefused { get; set; }
     }
 }

--- a/src/Cake.Curl/CurlSettings.cs
+++ b/src/Cake.Curl/CurlSettings.cs
@@ -106,7 +106,7 @@ namespace Cake.Curl
         /// By using <a href="https://curl.haxx.se/docs/manpage.html#--retry-delay">--retry-delay</a> you disable this exponential backoff algorithm.
         /// See also <a href="https://curl.haxx.se/docs/manpage.html#--retry-max-time">--retry-max-time</a> to limit the total time allowed for retries.
         /// </remarks>
-        public uint Retry { get; set; }
+        public uint RetryCount { get; set; }
 
         /// <summary>
         /// Gets or sets the amount of time in seconds before each retry when a transfer has failed with a transient error
@@ -116,7 +116,7 @@ namespace Cake.Curl
         /// This option is only interesting if <a href="https://curl.haxx.se/docs/manpage.html#--retry">--retry</a> is also used.
         /// Setting this delay to zero will make curl use the default backoff time.
         /// </remarks>
-        public uint RetryDelay { get; set; }
+        public uint RetryDelaySeconds { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time in seconds for retries to be done.
@@ -128,7 +128,7 @@ namespace Cake.Curl
         /// To limit a single request´s maximum time, use <a href="https://curl.haxx.se/docs/manpage.html#-m">--max-time</a>.
         /// Set this option to zero to not timeout retries.
         /// </remarks>
-        public uint RetryMaxTime { get; set; }
+        public uint RetryMaxTimeSeconds { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether curl should consider <code>ECONNREFUSED</code> (in addition to the other conditions) as a transient error
@@ -137,6 +137,6 @@ namespace Cake.Curl
         /// <remarks>
         /// This option is used together with <a href="https://curl.haxx.se/docs/manpage.html#--retry">--retry</a>.
         /// </remarks>
-        public bool RetryConnRefused { get; set; }
+        public bool RetryOnConnectionRefused { get; set; }
     }
 }


### PR DESCRIPTION
Added configuration options:

- [--retry](https://curl.haxx.se/docs/manpage.html#--retry)
- [--retry-delay](https://curl.haxx.se/docs/manpage.html#--retry-delay)
- [--retry-max-time](https://curl.haxx.se/docs/manpage.html#--retry-max-time)
- [--retry-connrefused](https://curl.haxx.se/docs/manpage.html#--retry-connrefused)